### PR TITLE
updated SBitstreamLike

### DIFF
--- a/src/types/sbitstream.jl
+++ b/src/types/sbitstream.jl
@@ -39,7 +39,7 @@ SBitstream{T}(value::Real) where {T<:Real} = SBitstream(convert(T, value))
 Base.convert(::Type{SBitstream{T}}, s::SBitstream) where {T<:Real} =
     SBitstream{T}(s.bits, convert(T, s.value), s.id)
 
-const SBitstreamLike = Union{<:SBitstream, VecOrMat{<:SBitstream}}
+    const SBitstreamLike = Union{<:SBitstream, VecOrMat{<:SBitstream}, Array{<:SBitstream}}
 
 Base.float(s::SBitstream) = s.value
 Base.zero(::SBitstream{T}) where T = SBitstream(zero(T))

--- a/src/types/sbitstream.jl
+++ b/src/types/sbitstream.jl
@@ -39,7 +39,7 @@ SBitstream{T}(value::Real) where {T<:Real} = SBitstream(convert(T, value))
 Base.convert(::Type{SBitstream{T}}, s::SBitstream) where {T<:Real} =
     SBitstream{T}(s.bits, convert(T, s.value), s.id)
 
-    const SBitstreamLike = Union{<:SBitstream, VecOrMat{<:SBitstream}, Array{<:SBitstream}}
+const SBitstreamLike = Union{<:SBitstream, AbstractArray{<:SBitstream}}
 
 Base.float(s::SBitstream) = s.value
 Base.zero(::SBitstream{T}) where T = SBitstream(zero(T))


### PR DESCRIPTION
Hi Kyle,

I changed SBitstreamLike so that I could define operators with tensor outputs larger than 2D. It worked for me but I don't know if this would break something somewhere else.