### PR TITLE
Fix cases of scalar + array w/o broadcast for simulation

### DIFF
--- a/docs/Artifacts.toml
+++ b/docs/Artifacts.toml
@@ -1,7 +1,7 @@
 [flux-theme]
 lazy = true
-git-tree-sha1 = "6e4be8bec8da9323c18d777d7855ef79dddcf524"
+git-tree-sha1 = "19bd94aa0a679bb380783d966e0c6d4ea4e778f5"
 
     [[flux-theme.download]]
-    sha256 = "b00941248ecdb643a72960bbfda19a3128591eca3d7cbcb3bfb80a6ab1c7f99e"
-    url = "https://github.com/darsnack/flux-theme/releases/download/v0.2.1/flux-theme-0.2.1.tar.gz"
+    sha256 = "1601c44ac21cae7422d750bfe738753fa9b9450d10190727a06580b94614cf12"
+    url = "https://github.com/darsnack/flux-theme/releases/download/v0.2.2/flux-theme-0.2.2.tar.gz"

--- a/src/tracing/utilities.jl
+++ b/src/tracing/utilities.jl
@@ -19,7 +19,7 @@ _issimulatable(op) = false
 _issimulatable(var::Ghost.Variable) = 
     (_gettapeval(var) isa Base.Broadcast.Broadcasted) ? _issimulatable(_gettapeop(var)) :
                                                         _gettapeval(var) isa SBitstreamLike
-_issimulatable(input::Ghost.Input) = input.val isa SBitstreamLike
+_issimulatable(input::Ghost.Input) = _gettapeval(input) isa SBitstreamLike
 _issimulatable(call::Ghost.Call) = any(_issimulatable, call.args)
 
 _isbcast(::typeof(Base.broadcasted)) = true

--- a/src/types/sbitstream.jl
+++ b/src/types/sbitstream.jl
@@ -82,26 +82,25 @@ for (op, sim) in ((:+, :SSignedAdder),
                   (:/, :SSignedDivider))
     @eval begin
         is_trace_primitive(::Type{typeof($op)},
-                           ::Type{<:SBitstreamLike},
-                           ::Type{<:SBitstreamLike}) = true
+                           ::Type{<:SBitstream},
+                           ::Type{<:SBitstream}) = true
         is_trace_primitive(::Type{typeof(Base.broadcasted)},
                            ::Type{typeof($op)},
                            ::Type{<:SBitstreamLike},
                            ::Type{<:SBitstreamLike}) = true
         getsimulator(::typeof($op), x::SBitstream, y::SBitstream) = $(sim)()
-        getsimulator(::typeof($op), x::AbstractArray{<:SBitstream}, y::SBitstream) =
-            getsimulator.($op, x, y)
-        getsimulator(::typeof($op), x::SBitstream, y::AbstractArray{<:SBitstream}) =
-            getsimulator.($op, x, y)
-        getsimulator(::typeof($op),
-                     x::AbstractArray{<:SBitstream},
-                     y::AbstractArray{<:SBitstream}) = getsimulator.($op, x, y)
         getsimulator(::typeof(Base.broadcasted),
                      ::typeof($op),
                      x::SBitstreamLike,
                      y::SBitstreamLike) = getsimulator.($op, x, y)
     end
 end
+
+Base.:(*)(x::SBitstreamLike, y::SBitstreamLike) = x .* y
+is_trace_primitive(::Type{typeof(*)},
+                   ::Type{<:SBitstreamLike},
+                   ::Type{<:SBitstreamLike}) = true
+getsimulator(::typeof(*), x::SBitstreamLike, y::SBitstreamLike) = getsimulator.(*, x, y)
 
 function Base.:(÷)(x::SBitstream, y::Real)
     if y < 1

--- a/src/types/sbitstream.jl
+++ b/src/types/sbitstream.jl
@@ -81,12 +81,21 @@ for (op, sim) in ((:+, :SSignedAdder),
                   (:*, :SSignedMultiplier),
                   (:/, :SSignedDivider))
     @eval begin
-        is_trace_primitive(::Type{typeof($op)}, ::Type{<:SBitstream}, ::Type{<:SBitstream}) = true
+        is_trace_primitive(::Type{typeof($op)},
+                           ::Type{<:SBitstreamLike},
+                           ::Type{<:SBitstreamLike}) = true
         is_trace_primitive(::Type{typeof(Base.broadcasted)},
                            ::Type{typeof($op)},
                            ::Type{<:SBitstreamLike},
                            ::Type{<:SBitstreamLike}) = true
         getsimulator(::typeof($op), x::SBitstream, y::SBitstream) = $(sim)()
+        getsimulator(::typeof($op), x::AbstractArray{<:SBitstream}, y::SBitstream) =
+            getsimulator.($op, x, y)
+        getsimulator(::typeof($op), x::SBitstream, y::AbstractArray{<:SBitstream}) =
+            getsimulator.($op, x, y)
+        getsimulator(::typeof($op),
+                     x::AbstractArray{<:SBitstream},
+                     y::AbstractArray{<:SBitstream}) = getsimulator.($op, x, y)
         getsimulator(::typeof(Base.broadcasted),
                      ::typeof($op),
                      x::SBitstreamLike,
@@ -118,6 +127,7 @@ is_trace_primitive(::Type{typeof(Base.broadcasted)},
 getsimulator(::typeof(sqrt), x::SBitstream) = SSquareRoot()
 getsimulator(::typeof(Base.broadcasted), ::typeof(sqrt), x::SBitstream) = getsimulator.(sqrt, x)
 
+decorrelate(x::Number) = x
 decorrelate(x::SBitstream) = SBitstream(float(x))
 is_trace_primitive(::Type{typeof(decorrelate)}, ::Type{<:SBitstream}) = true
 is_trace_primitive(::Type{typeof(Base.broadcasted)},

--- a/test/sbitstream.jl
+++ b/test/sbitstream.jl
@@ -123,27 +123,27 @@
                 z / T
             end ≈ float(max(x, y, w)) rtol = 0.1
         end
-        @testset "op = $op (matrix, scalar)" for op in (+, -, *, /)
-            sim = simulatable(op, X, y)
+        @testset "op = * (matrix, scalar)" begin
+            sim = simulatable(*, X, y)
             @test begin
                 Z = zeros(2, 2)
                 for t in 1:T
-                    bit = pop!.(sim(op, X, y))
+                    bit = pop!.(sim(*, X, y))
                     Z .+= pos.(bit) .- neg.(bit)
                 end
 
                 Z ./ T
-            end ≈ float.(op(X, y)) rtol = 0.1
-            sim = simulatable(op, y, X)
+            end ≈ float.(X * y) rtol = 0.1
+            sim = simulatable(*, y, X)
             @test begin
                 Z = zeros(2, 2)
                 for t in 1:T
-                    bit = pop!.(sim(op, y, X))
+                    bit = pop!.(sim(*, y, X))
                     Z .+= pos.(bit) .- neg.(bit)
                 end
 
                 Z ./ T
-            end ≈ float.(op(y, X)) rtol = 0.1
+            end ≈ float.(y * X) rtol = 0.1
         end
         @testset "op = * (matrix, matrix)" begin
             sim = simulatable(*, X, Y)

--- a/test/sbitstream.jl
+++ b/test/sbitstream.jl
@@ -123,6 +123,28 @@
                 z / T
             end ≈ float(max(x, y, w)) rtol = 0.1
         end
+        @testset "op = $op (matrix, scalar)" for op in (+, -, *, /)
+            sim = simulatable(op, X, y)
+            @test begin
+                Z = zeros(2, 2)
+                for t in 1:T
+                    bit = pop!.(sim(op, X, y))
+                    Z .+= pos.(bit) .- neg.(bit)
+                end
+
+                Z ./ T
+            end ≈ float.(op(X, y)) rtol = 0.1
+            sim = simulatable(op, y, X)
+            @test begin
+                Z = zeros(2, 2)
+                for t in 1:T
+                    bit = pop!.(sim(op, y, X))
+                    Z .+= pos.(bit) .- neg.(bit)
+                end
+
+                Z ./ T
+            end ≈ float.(op(y, X)) rtol = 0.1
+        end
         @testset "op = * (matrix, matrix)" begin
             sim = simulatable(*, X, Y)
             @test begin


### PR DESCRIPTION
Array operations in Julia allow `2 + rand(2, 2)` without broadcasting. Previously, this wasn't picked up as an implicitly broadcasted operation by BitSAD.