### PR TITLE
Use `LittleDict` instead of `Dict` to track `Ghost.Variable` keys

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitSAD"
 uuid = "7f90e340-ca22-4a3e-a259-118ed254aff3"
 authors = ["Kyle Daruwalla", "University of Wisconsin-Madison PHARM Group"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -12,6 +12,7 @@ LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -29,9 +30,9 @@ julia = "1.6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [publish]
-title = "BitSAD.jl"
-theme = "_flux-theme"
 ignore = ["^(gh-pages|juliamnt|julia.dmg)$"]
+theme = "_flux-theme"
+title = "BitSAD.jl"
 
 [targets]
 test = ["Test"]

--- a/src/BitSAD.jl
+++ b/src/BitSAD.jl
@@ -5,6 +5,7 @@ using DataStructures
 using Random: MersenneTwister
 using Setfield
 using Ghost
+using OrderedCollections: LittleDict
 using MacroTools: @capture
 using LightGraphs, MetaGraphs
 using Base: @kwdef


### PR DESCRIPTION
`Ghost.Variable` has hashing issues which seem to have resurfaced in the popped variable map in simulatable context. Now we use `LittleDict` which compares keys using equality. This is slower (O(n) vs O(1)), but it shouldn't be the bottleneck in any program.